### PR TITLE
Updated Combat Log + Attack Modal + Encounter

### DIFF
--- a/frontend/src/components/modals/AttackModal.tsx
+++ b/frontend/src/components/modals/AttackModal.tsx
@@ -7,12 +7,12 @@ import { GetMaxValueForDice } from "../../utils";
 interface AttackModalProps {
     open: boolean;
     onClose: (result?: { totalDamageDealt: number }) => void;
-    payload: { damageDices: [Dice, number][] };
+    payload: { damageDice: [Dice, number][] };
 }
 
 export default function AttackModal({ open, onClose, payload }: AttackModalProps) {
-    const { damageDices = [] } = payload || {};
-    const initialDamageValues = damageDices.map(([_, num]) => Array(num).fill(''));
+    const { damageDice = [] } = payload || {};
+    const initialDamageValues = damageDice.map(([_, num]) => Array(num).fill(''));
     const [damageValues, setDamageValues] = useState<number[][]>(initialDamageValues);
     const [totalDamage, setTotalDamage] = useState<number>(0);
 
@@ -23,7 +23,7 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
 
     const handleInputChange = (diceIndex: number, rollIndex: number, value: string) => {
         const intValue = parseInt(value, 10);
-        const maxValue = GetMaxValueForDice(damageDices[diceIndex][0]);
+        const maxValue = GetMaxValueForDice(damageDice[diceIndex][0]);
         if (!isNaN(intValue) && intValue >= 0 && intValue <= maxValue) {
             const newValues = [...damageValues];
             newValues[diceIndex][rollIndex] = intValue;
@@ -36,7 +36,7 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
     };
 
     const randomizeValues = () => {
-        const randomizedValues = damageDices.map(([dice, num]) => 
+        const randomizedValues = damageDice.map(([dice, num]) =>
             Array(num).fill(null).map(() => Math.floor(Math.random() * GetMaxValueForDice(dice)) + 1)
         );
         setDamageValues(randomizedValues);
@@ -47,7 +47,7 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
         let isValid = true;
 
         damageValues.forEach((diceValues, diceIndex) => {
-            const maxValue = GetMaxValueForDice(damageDices[diceIndex][0]);
+            const maxValue = GetMaxValueForDice(damageDice[diceIndex][0]);
             diceValues.forEach((value) => {
                 const intValue = parseInt(value, 10);
                 if (isNaN(intValue) || intValue <= 0 || intValue > maxValue) {
@@ -83,7 +83,7 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
                     Roll Damage
                 </Typography>
 
-                {damageDices.map(([dice, num], diceIndex) => (
+                {damageDice.map(([dice, num], diceIndex) => (
                     <Box key={diceIndex} sx={{ mb: 2 }}>
                         <Grid container spacing={2}>
                             {damageValues[diceIndex].map((value, rollIndex) => (

--- a/frontend/src/components/modals/AttackModal.tsx
+++ b/frontend/src/components/modals/AttackModal.tsx
@@ -1,5 +1,6 @@
-import { Box, Button, Dialog, Grid, TextField, Typography } from "@mui/material";
-import { useState } from "react";
+import { Box, Button, Dialog, Grid, TextField, Typography, IconButton } from "@mui/material";
+import { useState, useEffect } from "react";
+import { Casino } from "@mui/icons-material";
 import { Dice } from "../../../../shared/enums";
 import { GetMaxValueForDice } from "../../utils";
 
@@ -13,6 +14,12 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
     const { damageDices = [] } = payload || {};
     const initialDamageValues = damageDices.map(([_, num]) => Array(num).fill(''));
     const [damageValues, setDamageValues] = useState<number[][]>(initialDamageValues);
+    const [totalDamage, setTotalDamage] = useState<number>(0);
+
+    useEffect(() => {
+        const sum = damageValues.flat().reduce((acc, value) => acc + (parseInt(value, 10) || 0), 0);
+        setTotalDamage(sum);
+    }, [damageValues]);
 
     const handleInputChange = (diceIndex: number, rollIndex: number, value: string) => {
         const intValue = parseInt(value, 10);
@@ -21,17 +28,24 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
             const newValues = [...damageValues];
             newValues[diceIndex][rollIndex] = intValue;
             setDamageValues(newValues);
-        } else if (value === '') { 
+        } else if (value === '') {
             const newValues = [...damageValues];
             newValues[diceIndex][rollIndex] = 0;
             setDamageValues(newValues);
         }
     };
 
+    const randomizeValues = () => {
+        const randomizedValues = damageDices.map(([dice, num]) => 
+            Array(num).fill(null).map(() => Math.floor(Math.random() * GetMaxValueForDice(dice)) + 1)
+        );
+        setDamageValues(randomizedValues);
+    };
+
     const onAttack = () => {
         let totalDamageDealt = 0;
         let isValid = true;
-    
+
         damageValues.forEach((diceValues, diceIndex) => {
             const maxValue = GetMaxValueForDice(damageDices[diceIndex][0]);
             diceValues.forEach((value) => {
@@ -43,7 +57,7 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
                 }
             });
         });
-    
+
         if (isValid) {
             onClose({ totalDamageDealt });
         } else {
@@ -88,8 +102,16 @@ export default function AttackModal({ open, onClose, payload }: AttackModalProps
                     </Box>
                 ))}
 
-                {/* Attack Button */}
+                {/* Total Damage */}
+                <Typography variant="h6" sx={{ mt: 2, textAlign: 'center' }}>
+                    Total Damage: {totalDamage}
+                </Typography>
+
+                {/* Buttons */}
                 <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, mt: 2 }}>
+                    <IconButton onClick={randomizeValues} color="primary">
+                        <Casino />
+                    </IconButton>
                     <Button onClick={onCancel} color="error">
                         Cancel
                     </Button>

--- a/frontend/src/components/modals/EncounterAddFromPlayers.tsx
+++ b/frontend/src/components/modals/EncounterAddFromPlayers.tsx
@@ -46,7 +46,7 @@ function EncounterAddFromPlayers({ open, onClose }: { open: boolean; onClose: (p
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
             Add from player list
           </Typography>
-          <List>
+          <List sx={{ maxHeight: 300, overflowY: 'auto' }}>
             {playerList.map((player) => (
               <ListItemButton
                 key={player._id}
@@ -58,20 +58,21 @@ function EncounterAddFromPlayers({ open, onClose }: { open: boolean; onClose: (p
               </ListItemButton>
             ))}
           </List>
-          <Button
-            variant="contained"
-            color="primary"
-            fullWidth
-            sx={{ mt: 2 }}
-            disabled={!selectedPlayer}
-            onClick={handleAddToQueue}
-          >
-            Add to initiative queue
-          </Button>
+          <Box sx={{ position: 'sticky', bottom: 0, p: 2 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              fullWidth
+              disabled={!selectedPlayer}
+              onClick={handleAddToQueue}
+            >
+              Add to initiative queue
+            </Button>
+          </Box>
         </Paper>
       </Box>
     </Dialog>
   );
-};
+}
 
 export default EncounterAddFromPlayers;

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -442,7 +442,7 @@ export default function Encounter() {
         return (
           <Box sx={sxProps.targetSection}>
             <Typography variant="h6">{selectedTarget.name}</Typography>
-            <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+            <Box sx={{ display: 'flex', gap: 1}}>
                 
                     {/* Status */}
                     <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
@@ -595,38 +595,70 @@ export default function Encounter() {
                 <Typography variant="h6" sx={sxProps.columnTitle}>INITIATIVE</Typography>
                 {players.map((character, index) => (
                     <Card
-                        key={character._id}
-                        sx={{ ...sxProps.columnCard, ...sxProps.initiativeItem, ...(isActive(character.name) && sxProps.initiativeItemActive) }}
+                    key={character._id}
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        ...sxProps.columnCard,
+                        ...sxProps.initiativeItem,
+                        ...(isActive(character.name) && sxProps.initiativeItemActive),
+                    }}
+                >
+                    <Typography
+                        sx={{
+                            fontWeight: 'bold',
+                            fontSize: '24px',
+                            textAlign: 'center',
+                            p: 1,
+                            backgroundColor: 'primary.dark',
+                            color: 'white',
+                            height: '100%',
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                            width: '40px',
+                            borderRadius: '5px',
+                        }}
                     >
-                        <Typography>{index + 1}. {character.name}</Typography>
-                        <Typography>Level {character.level} {character.class}</Typography>
+                        {index + 1}
+                    </Typography>
+                
+                    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: 2 }}>
+                        <Typography sx={{ fontWeight: 'bold', mb: 1 }}>{character.name}</Typography>
+                        <Typography sx={{ mb: 1 }}>
+                            Level {character.level} {character.class}
+                        </Typography>
                         <ToggleButtonGroup
                             value={formatsByCharacter[character.name] || []}
                             onChange={(event, newFormats) => handleFormat(character.name, event, newFormats)}
-                            sx={{ maxHeight: '40px' }}>
-                            {['action', 'bonus', 'reaction'].map(type => (
+                            sx={{ maxHeight: '40px' }}
+                        >
+                            {['action', 'bonus', 'reaction'].map((type) => (
                                 <ToggleButton
                                     key={type}
                                     value={type}
                                     sx={{
                                         backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
-                                            ? 'primary.dark' //when selected
-                                            : 'primary.main', //not selcted
+                                            ? 'primary.dark' // when selected
+                                            : 'primary.main', // not selected
                                         color: (formatsByCharacter[character.name] || []).includes(type)
-                                            ? 'black' //selected
-                                            : 'white', //notselected
+                                            ? 'black' // selected
+                                            : 'white', // not selected
                                         '&:hover': {
                                             backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
-                                                ? 'primary.main' //hoverselected
+                                                ? 'primary.main' // hover selected
                                                 : 'primary.dark',
-                                            color: 'white' //hovertext
-                                        }
-                                    }}>
+                                            color: 'white', // hover text
+                                        },
+                                    }}
+                                >
                                     {type.charAt(0).toUpperCase() + type.slice(1)}
                                 </ToggleButton>
                             ))}
                         </ToggleButtonGroup>
-                    </Card>
+                    </Box>
+                </Card>
+                
                 ))}
                 <Card sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 1, borderRadius: 0.5 }}>
                     <IconButton size="small" >
@@ -652,7 +684,7 @@ export default function Encounter() {
             {/* PLAYER SELECTED OR CURRENT TURN IN INITIATIVE ORDER IN QUEUE */}
             <Box sx={sxProps.encounterColumn}>
                 <Typography variant="h6" sx={sxProps.columnTitle}>CURRENT TURN</Typography> {/* Should this display character name instead? */} 
-                <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+                <Box sx={{ display: 'flex', gap: 1 }}>
                 
                     {/* Status */}
                     <Card sx={{ ...sxProps.columnCard, flex: 1 }}>

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -443,134 +443,135 @@ export default function Encounter() {
           <Box sx={sxProps.targetSection}>
             <Typography variant="h6">{selectedTarget.name}</Typography>
             <Card sx={sxProps.columnCard}>
-              <Typography variant="subtitle2">Status</Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                <Typography>Hit Points:</Typography>
-                <TextField
-                  type="number"
-                  value={selectedTarget.hp}
-                  onChange={(e) => handleTargetStatChange('hp', e.target.value)}
-                  size="small"
-                  sx={{ width: 60 }}
-                />
-                <Typography>/</Typography>
-                <TextField
-                  type="number"
-                  value={selectedTarget.maxHp}
-                  onChange={(e) => handleTargetStatChange('maxHp', e.target.value)}
-                  size="small"
-                  sx={{ width: 60 }}
-                />
-              </Box>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                <Typography>Temp HP:</Typography>
-                <TextField
-                  type="number"
-                  value={selectedTarget.tempHp || 0}
-                  onChange={(e) => handleTargetStatChange('tempHp', e.target.value)}
-                  size="small"
-                  sx={{ width: 60 }}
-                />
-              </Box>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Typography>AC:</Typography>
-                <TextField
-                  type="number"
-                  value={selectedTarget.ac}
-                  onChange={(e) => handleTargetStatChange('ac', e.target.value)}
-                  size="small"
-                  sx={{ width: 60 }}
-                />
-              </Box>
-            <Box sx={sxProps.deathSaves}>
-                <Typography>☠</Typography>
-                <Box>□□□□□</Box>
-            </Box>
-            <Box sx={sxProps.targetSection}>
-                <Card sx={sxProps.columnCard}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                        <Typography variant="subtitle2">Conditions</Typography>
-                        <IconButton size="small" onClick={handleConditionsOpen}><AddIcon /></IconButton>
-                    </Box>
-                    {loadingConditions ? (
-                        <Box display="flex" justifyContent="center" alignItems="center" height={50}>
-                            <CircularProgress size={24} />
+                {/* Status */}
+                <Typography variant="subtitle2">Status</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Typography>HP</Typography>
+                    <TextField
+                      type="number"
+                      value={selectedTarget.hp}
+                      onChange={(e) => handleTargetStatChange('hp', e.target.value)}
+                      size="small"
+                      sx={{ width: 60 }}
+                    />
+                    <Typography>/</Typography>
+                    <TextField
+                      type="number"
+                      value={selectedTarget.maxHp}
+                      onChange={(e) => handleTargetStatChange('maxHp', e.target.value)}
+                      size="small"
+                      sx={{ width: 60 }}
+                    />
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Typography>Temp HP</Typography>
+                    <TextField
+                      type="number"
+                      value={selectedTarget.tempHp || 0}
+                      onChange={(e) => handleTargetStatChange('tempHp', e.target.value)}
+                      size="small"
+                      sx={{ width: 60 }}
+                    />
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography>AC</Typography>
+                    <TextField
+                      type="number"
+                      value={selectedTarget.ac}
+                      onChange={(e) => handleTargetStatChange('ac', e.target.value)}
+                      size="small"
+                      sx={{ width: 60 }}
+                    />
+                </Box>
+                <Box sx={sxProps.deathSaves}>
+                    <Typography>☠</Typography>
+                    <Box>□□□□□</Box>
+                </Box>
+                <Box sx={sxProps.targetSection}>
+                    <Card sx={sxProps.columnCard}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                            <Typography variant="subtitle2">Conditions</Typography>
+                            <IconButton size="small" onClick={handleConditionsOpen}><AddIcon /></IconButton>
                         </Box>
-                    ) : (
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                            {selectedConditions.map((condition, index) => (
-                                <Chip
-                                    key={index}
-                                    label={condition}
-                                    size="small"
-                                    color="primary"
-                                    onDelete={() => handleDeleteCondition(condition)}
-                                />
-                            ))}
-                            {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
+                        {loadingConditions ? (
+                            <Box display="flex" justifyContent="center" alignItems="center" height={50}>
+                                <CircularProgress size={24} />
+                            </Box>
+                        ) : (
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                {selectedConditions.map((condition, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={condition}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteCondition(condition)}
+                                    />
+                                ))}
+                                {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
+                            </Box>
+                        )}
+                    </Card>
+                    <Card sx={sxProps.columnCard}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                            <Typography variant="subtitle2">Defenses</Typography>
+                            <IconButton size="small" onClick={handleDefensesOpen}><AddIcon /></IconButton>
                         </Box>
-                    )}
-                </Card>
-                <Card sx={sxProps.columnCard}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                        <Typography variant="subtitle2">Defenses</Typography>
-                        <IconButton size="small" onClick={handleDefensesOpen}><AddIcon /></IconButton>
-                    </Box>
-                    {loadingDefenses ? (
-                        <Box display="flex" justifyContent="center" alignItems="center" height={100}>
-                            <CircularProgress size={24} />
-                        </Box>
-                    ) : (
-                        <>
-                            <Box sx={{ mb: 1 }}>
-                                <Typography variant="body2">Immunities</Typography>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                    {selectedImmunities.map((immunity, index) => (
-                                        <Chip
-                                            key={index}
-                                            label={immunity}
-                                            size="small"
-                                            color="primary"
-                                            onDelete={() => handleDeleteImmunity(immunity)}
-                                        />
-                                    ))}
-                                    {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
-                                </Box>
+                        {loadingDefenses ? (
+                            <Box display="flex" justifyContent="center" alignItems="center" height={100}>
+                                <CircularProgress size={24} />
                             </Box>
-                            <Box sx={{ mb: 1 }}>
-                                <Typography variant="body2">Resistances</Typography>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                    {selectedResistances.map((resistance, index) => (
-                                        <Chip
-                                            key={index}
-                                            label={resistance}
-                                            size="small"
-                                            color="primary"
-                                            onDelete={() => handleDeleteResistance(resistance)}
-                                        />
-                                    ))}
-                                    {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
+                        ) : (
+                            <>
+                                <Box sx={{ mb: 1 }}>
+                                    <Typography variant="body2">Immunities</Typography>
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                        {selectedImmunities.map((immunity, index) => (
+                                            <Chip
+                                                key={index}
+                                                label={immunity}
+                                                size="small"
+                                                color="primary"
+                                                onDelete={() => handleDeleteImmunity(immunity)}
+                                            />
+                                        ))}
+                                        {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
+                                    </Box>
                                 </Box>
-                            </Box>
-                            <Box>
-                                <Typography variant="body2">Vulnerabilities</Typography>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                    {selectedVulnerabilities.map((vulnerability, index) => (
-                                        <Chip
-                                            key={index}
-                                            label={vulnerability}
-                                            size="small"
-                                            color="primary"
-                                            onDelete={() => handleDeleteVulnerability(vulnerability)}
-                                        />
-                                    ))}
-                                    {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
+                                <Box sx={{ mb: 1 }}>
+                                    <Typography variant="body2">Resistances</Typography>
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                        {selectedResistances.map((resistance, index) => (
+                                            <Chip
+                                                key={index}
+                                                label={resistance}
+                                                size="small"
+                                                color="primary"
+                                                onDelete={() => handleDeleteResistance(resistance)}
+                                            />
+                                        ))}
+                                        {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
+                                    </Box>
                                 </Box>
-                            </Box>
-                        </>
-                    )}
-                </Card>
-            </Box>
+                                <Box>
+                                    <Typography variant="body2">Vulnerabilities</Typography>
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                        {selectedVulnerabilities.map((vulnerability, index) => (
+                                            <Chip
+                                                key={index}
+                                                label={vulnerability}
+                                                size="small"
+                                                color="primary"
+                                                onDelete={() => handleDeleteVulnerability(vulnerability)}
+                                            />
+                                        ))}
+                                        {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
+                                    </Box>
+                                </Box>
+                            </>
+                        )}
+                    </Card>
+                </Box>
             </Card>
           </Box>
         );
@@ -638,120 +639,145 @@ export default function Encounter() {
 
             {/* PLAYER SELECTED OR CURRENT TURN IN INITIATIVE ORDER IN QUEUE */}
             <Box sx={sxProps.encounterColumn}>
-                <Card sx={sxProps.columnCard}>
-                    <Typography variant="subtitle2">Status</Typography>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <Typography>Hit Points:</Typography>
-                        <TextField
-                            type="number"
-                            value={currentHP}
-                            onChange={handleCurrentHPChange}
-                            size="small"
-                            sx={{ width: 60 }}
-                        />
-                        <Typography>/</Typography>
-                        <TextField
-                            type="number"
-                            value={maxHP}
-                            onChange={handleMaxHPChange}
-                            size="small"
-                            sx={{ width: 60 }}
-                        />
-                    </Box>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <Typography>Temp HP:</Typography>
-                        <TextField
-                            type="number"
-                            value={tempHP}
-                            onChange={handleTempHPChange}
-                            size="small"
-                            sx={{ width: 100 }}
-                        />
-                    </Box>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography>AC:</Typography>
-                        <TextField
-                            type="number"
-                            value={armorClass}
-                            onChange={handleArmorClassChange}
-                            size="small"
-                            sx={{ width: 100 }}
-                        />
-                    </Box>
-                </Card>
-
-                {/* Conditions Box */}
-                <Card sx={sxProps.columnCard}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                        <Typography variant="subtitle2">Conditions</Typography>
-                        <IconButton size="small" onClick={handleConditionsOpen}><AddIcon /></IconButton>
-                    </Box>
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                        {selectedConditions.map((condition, index) => (
-                            <Chip
-                                key={index}
-                                label={condition}
+                <Typography variant="h6" sx={sxProps.columnTitle}>CURRENT TURN</Typography> {/* Should this display character name instead? */} 
+                <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+                
+                    {/* Status */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Typography variant="subtitle2">Status</Typography>
+                                
+                        {/* HP Row */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>HP</Typography>
+                            <TextField
+                                type="number"
+                                value={currentHP}
+                                onChange={handleCurrentHPChange}
                                 size="small"
-                                color="primary"
-                                onDelete={() => handleDeleteCondition(condition)}
+                                sx={{ width: 60, ml: 'auto' }}  // Text field aligned to the right
                             />
-                        ))}
-                        {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
-                    </Box>
-                </Card>
+                            <Typography>/</Typography>
+                            <TextField
+                                type="number"
+                                value={maxHP}
+                                onChange={handleMaxHPChange}
+                                size="small"
+                                sx={{ width: 60 }}
+                            />
+                        </Box>
+                                
+                        {/* Temp HP Row */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>Temp HP</Typography>
+                            <TextField
+                                type="number"
+                                value={tempHP}
+                                onChange={handleTempHPChange}
+                                size="small"
+                                sx={{ width: 100, ml: 'auto' }}  // Text field aligned to the right
+                            />
+                        </Box>
+                                
+                        {/* AC Row */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>AC</Typography>
+                            <TextField
+                                type="number"
+                                value={armorClass}
+                                onChange={handleArmorClassChange}
+                                size="small"
+                                sx={{ width: 100, ml: 'auto' }}  // Text field aligned to the right
+                            />
+                        </Box>
+                    </Card>
 
-                {/* Defenses Box */}
-                <Card sx={sxProps.columnCard}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                        <Typography variant="subtitle2">Defenses</Typography>
-                        <IconButton size="small" onClick={handleDefensesOpen}><AddIcon /></IconButton>
-                    </Box>
-                    <Box sx={{ mb: 1 }}>
-                        <Typography variant="body2">Immunities</Typography>
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                            {selectedImmunities.map((immunity, index) => (
+
+                    {/* Notes */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Typography variant="subtitle2">Notes</Typography>
+                        <TextField fullWidth multiline rows={4} placeholder="Add notes here..." />
+                    </Card>
+                    
+                </Box>
+                
+
+                <Box sx={{ display: 'flex', gap: 1 }}>
+
+                    {/* Conditions Section */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                            <Typography variant="subtitle2">Conditions</Typography>
+                            <IconButton size="small" onClick={handleConditionsOpen}><AddIcon /></IconButton>
+                        </Box>
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                            {selectedConditions.map((condition, index) => (
                                 <Chip
                                     key={index}
-                                    label={immunity}
+                                    label={condition}
                                     size="small"
                                     color="primary"
-                                    onDelete={() => handleDeleteImmunity(immunity)}
+                                    onDelete={() => handleDeleteCondition(condition)}
                                 />
                             ))}
-                            {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
+                            {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
                         </Box>
-                    </Box>
-                    <Box sx={{ mb: 1 }}>
-                        <Typography variant="body2">Resistances</Typography>
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                            {selectedResistances.map((resistance, index) => (
-                                <Chip
-                                    key={index}
-                                    label={resistance}
-                                    size="small"
-                                    color="primary"
-                                    onDelete={() => handleDeleteResistance(resistance)}
-                                />
-                            ))}
-                            {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
+                    </Card>
+                        
+                    {/* Defenses Section */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                            <Typography variant="subtitle2">Defenses</Typography>
+                            <IconButton size="small" onClick={handleDefensesOpen}><AddIcon /></IconButton>
                         </Box>
-                    </Box>
-                    <Box>
-                        <Typography variant="body2">Vulnerabilities</Typography>
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                            {selectedVulnerabilities.map((vulnerability, index) => (
-                                <Chip
-                                    key={index}
-                                    label={vulnerability}
-                                    size="small"
-                                    color="primary"
-                                    onDelete={() => handleDeleteVulnerability(vulnerability)}
-                                />
-                            ))}
-                            {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
+                        <Box sx={{ mb: 1 }}>
+                            <Typography variant="body2">Immunities</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedImmunities.map((immunity, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={immunity}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteImmunity(immunity)}
+                                    />
+                                ))}
+                                {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
+                            </Box>
                         </Box>
-                    </Box>
-                </Card>
+                        <Box sx={{ mb: 1 }}>
+                            <Typography variant="body2">Resistances</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedResistances.map((resistance, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={resistance}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteResistance(resistance)}
+                                    />
+                                ))}
+                                {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
+                            </Box>
+                        </Box>
+                        <Box>
+                            <Typography variant="body2">Vulnerabilities</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedVulnerabilities.map((vulnerability, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={vulnerability}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteVulnerability(vulnerability)}
+                                    />
+                                ))}
+                                {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
+                            </Box>
+                        </Box>
+                    </Card>
+
+                </Box>
+
                 <Card sx={sxProps.columnCard}>
                     <Box sx={sxProps.actionGroup}>
                         <Box sx={sxProps.actionItem}>
@@ -773,10 +799,6 @@ export default function Encounter() {
                         </Box>
                         <Button variant="contained" color="primary" onClick={handleExecute}>EXECUTE</Button>
                     </Box>
-                </Card>
-                <Card sx={sxProps.columnCard}>
-                    <Typography variant="subtitle2">Notes</Typography>
-                    <TextField fullWidth multiline rows={4} placeholder="Add notes here..." />
                 </Card>
             </Box>
 

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -442,137 +442,149 @@ export default function Encounter() {
         return (
           <Box sx={sxProps.targetSection}>
             <Typography variant="h6">{selectedTarget.name}</Typography>
-            <Card sx={sxProps.columnCard}>
-                {/* Status */}
-                <Typography variant="subtitle2">Status</Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                    <Typography>HP</Typography>
-                    <TextField
-                      type="number"
-                      value={selectedTarget.hp}
-                      onChange={(e) => handleTargetStatChange('hp', e.target.value)}
-                      size="small"
-                      sx={{ width: 60 }}
-                    />
-                    <Typography>/</Typography>
-                    <TextField
-                      type="number"
-                      value={selectedTarget.maxHp}
-                      onChange={(e) => handleTargetStatChange('maxHp', e.target.value)}
-                      size="small"
-                      sx={{ width: 60 }}
-                    />
+            <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+                
+                    {/* Status */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Typography variant="subtitle2">Status</Typography>
+
+                        {/* HP */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>HP</Typography>
+                            <TextField
+                                type="number"
+                                value={selectedTarget.hp}
+                                onChange={handleCurrentHPChange}
+                                size="small"
+                                sx={{ width: 60, ml: 'auto' }}
+                            />
+                            <Typography>/</Typography>
+                            <TextField
+                                type="number"
+                                value={selectedTarget.maxHp}
+                                onChange={handleMaxHPChange}
+                                size="small"
+                                sx={{ width: 60 }}
+                            />
+                        </Box>
+
+                        {/* Temp HP */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>Temp HP</Typography>
+                            <TextField
+                                type="number"
+                                value={selectedTarget.tempHp}
+                                onChange={handleTempHPChange}
+                                size="small"
+                                sx={{ width: 100, ml: 'auto' }}
+                            />
+                        </Box>
+
+                        {/* AC */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Typography sx={{ flexGrow: 1 }}>AC</Typography>
+                            <TextField
+                                type="number"
+                                value={selectedTarget.ac}
+                                onChange={handleArmorClassChange}
+                                size="small"
+                                sx={{ width: 100, ml: 'auto' }}
+                            />
+                        </Box>
+
+                        {/* Death Saves */}
+                        <Box sx={sxProps.deathSaves}>
+                            <Typography>☠</Typography>
+                            <Box>□□□□□</Box>
+                        </Box>
+                    </Card>
+
+
+                    {/* Notes */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
+                        <Typography variant="subtitle2">Notes</Typography>
+                        <TextField fullWidth multiline rows={4} placeholder="Add notes here..." />
+                    </Card>
+                    
                 </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                    <Typography>Temp HP</Typography>
-                    <TextField
-                      type="number"
-                      value={selectedTarget.tempHp || 0}
-                      onChange={(e) => handleTargetStatChange('tempHp', e.target.value)}
-                      size="small"
-                      sx={{ width: 60 }}
-                    />
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Typography>AC</Typography>
-                    <TextField
-                      type="number"
-                      value={selectedTarget.ac}
-                      onChange={(e) => handleTargetStatChange('ac', e.target.value)}
-                      size="small"
-                      sx={{ width: 60 }}
-                    />
-                </Box>
-                <Box sx={sxProps.deathSaves}>
-                    <Typography>☠</Typography>
-                    <Box>□□□□□</Box>
-                </Box>
-                <Box sx={sxProps.targetSection}>
-                    <Card sx={sxProps.columnCard}>
+                
+
+                <Box sx={{ display: 'flex', gap: 1 }}>
+
+                    {/* Conditions */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                             <Typography variant="subtitle2">Conditions</Typography>
                             <IconButton size="small" onClick={handleConditionsOpen}><AddIcon /></IconButton>
                         </Box>
-                        {loadingConditions ? (
-                            <Box display="flex" justifyContent="center" alignItems="center" height={50}>
-                                <CircularProgress size={24} />
-                            </Box>
-                        ) : (
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                {selectedConditions.map((condition, index) => (
-                                    <Chip
-                                        key={index}
-                                        label={condition}
-                                        size="small"
-                                        color="primary"
-                                        onDelete={() => handleDeleteCondition(condition)}
-                                    />
-                                ))}
-                                {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
-                            </Box>
-                        )}
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                            {selectedConditions.map((condition, index) => (
+                                <Chip
+                                    key={index}
+                                    label={condition}
+                                    size="small"
+                                    color="primary"
+                                    onDelete={() => handleDeleteCondition(condition)}
+                                />
+                            ))}
+                            {selectedConditions.length === 0 && <Typography>No conditions</Typography>}
+                        </Box>
                     </Card>
-                    <Card sx={sxProps.columnCard}>
+                        
+                    {/* Defenses */}
+                    <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                             <Typography variant="subtitle2">Defenses</Typography>
                             <IconButton size="small" onClick={handleDefensesOpen}><AddIcon /></IconButton>
                         </Box>
-                        {loadingDefenses ? (
-                            <Box display="flex" justifyContent="center" alignItems="center" height={100}>
-                                <CircularProgress size={24} />
+                        <Box sx={{ mb: 1 }}>
+                            <Typography variant="body2">Immunities</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedImmunities.map((immunity, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={immunity}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteImmunity(immunity)}
+                                    />
+                                ))}
+                                {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
                             </Box>
-                        ) : (
-                            <>
-                                <Box sx={{ mb: 1 }}>
-                                    <Typography variant="body2">Immunities</Typography>
-                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                        {selectedImmunities.map((immunity, index) => (
-                                            <Chip
-                                                key={index}
-                                                label={immunity}
-                                                size="small"
-                                                color="primary"
-                                                onDelete={() => handleDeleteImmunity(immunity)}
-                                            />
-                                        ))}
-                                        {selectedImmunities.length === 0 && <Typography>No immunities</Typography>}
-                                    </Box>
-                                </Box>
-                                <Box sx={{ mb: 1 }}>
-                                    <Typography variant="body2">Resistances</Typography>
-                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                        {selectedResistances.map((resistance, index) => (
-                                            <Chip
-                                                key={index}
-                                                label={resistance}
-                                                size="small"
-                                                color="primary"
-                                                onDelete={() => handleDeleteResistance(resistance)}
-                                            />
-                                        ))}
-                                        {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
-                                    </Box>
-                                </Box>
-                                <Box>
-                                    <Typography variant="body2">Vulnerabilities</Typography>
-                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
-                                        {selectedVulnerabilities.map((vulnerability, index) => (
-                                            <Chip
-                                                key={index}
-                                                label={vulnerability}
-                                                size="small"
-                                                color="primary"
-                                                onDelete={() => handleDeleteVulnerability(vulnerability)}
-                                            />
-                                        ))}
-                                        {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
-                                    </Box>
-                                </Box>
-                            </>
-                        )}
+                        </Box>
+                        <Box sx={{ mb: 1 }}>
+                            <Typography variant="body2">Resistances</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedResistances.map((resistance, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={resistance}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteResistance(resistance)}
+                                    />
+                                ))}
+                                {selectedResistances.length === 0 && <Typography>No resistances</Typography>}
+                            </Box>
+                        </Box>
+                        <Box>
+                            <Typography variant="body2">Vulnerabilities</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                                {selectedVulnerabilities.map((vulnerability, index) => (
+                                    <Chip
+                                        key={index}
+                                        label={vulnerability}
+                                        size="small"
+                                        color="primary"
+                                        onDelete={() => handleDeleteVulnerability(vulnerability)}
+                                    />
+                                ))}
+                                {selectedVulnerabilities.length === 0 && <Typography>No vulnerabilities</Typography>}
+                            </Box>
+                        </Box>
                     </Card>
+
                 </Box>
-            </Card>
           </Box>
         );
       };
@@ -689,6 +701,12 @@ export default function Encounter() {
                                 sx={{ width: 100, ml: 'auto' }}
                             />
                         </Box>
+
+                        {/* Death Saves */}
+                        <Box sx={sxProps.deathSaves}>
+                            <Typography>☠</Typography>
+                            <Box>□□□□□</Box>
+                        </Box>
                     </Card>
 
 
@@ -703,7 +721,7 @@ export default function Encounter() {
 
                 <Box sx={{ display: 'flex', gap: 1 }}>
 
-                    {/* Conditions Section */}
+                    {/* Conditions */}
                     <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                             <Typography variant="subtitle2">Conditions</Typography>
@@ -723,7 +741,7 @@ export default function Encounter() {
                         </Box>
                     </Card>
                         
-                    {/* Defenses Section */}
+                    {/* Defenses */}
                     <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                             <Typography variant="subtitle2">Defenses</Typography>

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -283,9 +283,9 @@ export default function Encounter() {
         },
         encounterColumn: {
             display: "flex",
-            flex: 1,
             flexDirection: "column",
-            gap: 1
+            gap: 1,
+            width: 'fit-content'
         },
         columnTitle: {
             marginBottom: 0.5
@@ -593,79 +593,83 @@ export default function Encounter() {
         <Box sx={sxProps.encounterScreen}>
             <Box sx={sxProps.encounterColumn}>
                 <Typography variant="h6" sx={sxProps.columnTitle}>INITIATIVE</Typography>
-                {players.map((character, index) => (
-                    <Card
-                    key={character._id}
-                    sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        ...sxProps.columnCard,
-                        ...sxProps.initiativeItem,
-                        ...(isActive(character.name) && sxProps.initiativeItemActive),
-                    }}
-                >
-                    <Typography
-                        sx={{
-                            fontWeight: 'bold',
-                            fontSize: '24px',
-                            textAlign: 'center',
-                            p: 1,
-                            backgroundColor: 'primary.dark',
-                            color: 'white',
-                            height: '100%',
-                            display: 'flex',
-                            justifyContent: 'center',
-                            alignItems: 'center',
-                            width: '40px',
-                            borderRadius: '5px',
-                        }}
-                    >
-                        {index + 1}
-                    </Typography>
-                
-                    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: 2 }}>
-                        <Typography sx={{ fontWeight: 'bold', mb: 1 }}>{character.name}</Typography>
-                        <Typography sx={{ mb: 1 }}>
-                            Level {character.level} {character.class}
-                        </Typography>
-                        <ToggleButtonGroup
-                            value={formatsByCharacter[character.name] || []}
-                            onChange={(event, newFormats) => handleFormat(character.name, event, newFormats)}
-                            sx={{ maxHeight: '40px' }}
+                <Box sx={{ maxHeight: '70vh', overflowY: 'auto', pr: 1 }}>
+                    {players.map((character, index) => (
+                        <Card
+                            key={character._id}
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                ...sxProps.columnCard,
+                                ...sxProps.initiativeItem,
+                                ...(isActive(character.name) && sxProps.initiativeItemActive),
+                                mb: 1
+                            }}
                         >
-                            {['action', 'bonus', 'reaction'].map((type) => (
-                                <ToggleButton
-                                    key={type}
-                                    value={type}
-                                    sx={{
-                                        backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
-                                            ? 'primary.dark' // when selected
-                                            : 'primary.main', // not selected
-                                        color: (formatsByCharacter[character.name] || []).includes(type)
-                                            ? 'black' // selected
-                                            : 'white', // not selected
-                                        '&:hover': {
-                                            backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
-                                                ? 'primary.main' // hover selected
-                                                : 'primary.dark',
-                                            color: 'white', // hover text
-                                        },
-                                    }}
+                            <Typography
+                                sx={{
+                                    fontWeight: 'bold',
+                                    fontSize: '3em',
+                                    textAlign: 'center',
+                                    p: 1,
+                                    backgroundColor: 'primary.dark',
+                                    height: '11.5vh',
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                    alignItems: 'center',
+                                    width: '60px',
+                                    borderRadius: '5px',
+                                }}
+                            >
+                                {index + 1}
+                            </Typography>
+                            
+                            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: 2 }}>
+                                <Typography sx={{ fontWeight: 'bold', mb: 1 }}>{character.name}</Typography>
+                                <Typography sx={{ mb: 1 }}>
+                                    Level {character.level} {character.class}
+                                </Typography>
+                                <ToggleButtonGroup
+                                    value={formatsByCharacter[character.name] || []}
+                                    onChange={(event, newFormats) => handleFormat(character.name, event, newFormats)}
+                                    sx={{ maxHeight: '40px' }}
                                 >
-                                    {type.charAt(0).toUpperCase() + type.slice(1)}
-                                </ToggleButton>
-                            ))}
-                        </ToggleButtonGroup>
-                    </Box>
-                </Card>
+                                    {['action', 'bonus', 'reaction'].map((type) => (
+                                        <ToggleButton
+                                            key={type}
+                                            value={type}
+                                            sx={{
+                                                backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
+                                                    ? 'primary.dark' // when selected
+                                                    : 'primary.main', // not selected
+                                                color: (formatsByCharacter[character.name] || []).includes(type)
+                                                    ? 'black' // selected
+                                                    : 'white', // not selected
+                                                '&:hover': {
+                                                    backgroundColor: (formatsByCharacter[character.name] || []).includes(type)
+                                                        ? 'primary.main' // hover selected
+                                                        : 'primary.dark',
+                                                    color: 'white', // hover text
+                                                },
+                                            }}
+                                        >
+                                            {type.charAt(0).toUpperCase() + type.slice(1)}
+                                        </ToggleButton>
+                                    ))}
+                                </ToggleButtonGroup>
+                            </Box>
+                        </Card>
+                    ))}
+                </Box>
                 
-                ))}
+                {/* Add Button */}
                 <Card sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 1, borderRadius: 0.5 }}>
-                    <IconButton size="small" >
-                        <AddIcon onClick={handleAddInitiative}/>
+                    <IconButton size="small">
+                        <AddIcon onClick={handleAddInitiative} />
                     </IconButton>
                 </Card>
-
+                
+                {/* Button Container */}
                 <Box ref={buttonContainerRef}>
                     <Collapse in={showButtons}>
                         <Button onClick={handleOpenPlayerList} variant="contained" color="primary" sx={{ width: '100%', marginTop: '5px', marginBottom: '5px' }}>
@@ -680,6 +684,7 @@ export default function Encounter() {
                     </Collapse>
                 </Box>
             </Box>
+
 
             {/* PLAYER SELECTED OR CURRENT TURN IN INITIATIVE ORDER IN QUEUE */}
             <Box sx={sxProps.encounterColumn}>

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { Send } from '@mui/icons-material';
+import { Send, CheckBoxOutlineBlank, CheckBox, Cancel } from '@mui/icons-material';
 import { Action, Dice, Weapon, WeaponCategories } from '../../../shared/enums.ts';
 import AddIcon from "@mui/icons-material/Add";
 import {
@@ -30,6 +30,25 @@ import { Player } from "../types.ts";
 import AttackModal from "../components/modals/AttackModal";
 import {apiService} from "../services/apiService.ts";
 
+const DeathSaveBox = ({ state, onClick }) => {
+    const renderIcon = () => {
+        switch (state) {
+            case 1:
+                return <CheckBox />; // Ticked
+            case 2:
+                return <Cancel />; // Crossed
+            default:
+                return <CheckBoxOutlineBlank />; // Empty
+        }
+    };
+
+    return (
+        <IconButton onClick={onClick}>
+            {renderIcon()}
+        </IconButton>
+    );
+};
+
 export default function Encounter() {
     const [hitPoints, setHitPoints] = useState("30/50");
     const [originalHitPoints, setOriginalHitPoints] = useState(hitPoints);
@@ -55,6 +74,8 @@ export default function Encounter() {
     const [currentHP, setCurrentHP] = useState(30);
     const [maxHP, setMaxHP] = useState(50);
 
+    const [deathSaves, setDeathSaves] = useState([0, 0, 0, 0, 0]);
+
     const handleCurrentHPChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = parseInt(e.target.value);
         setCurrentHP(isNaN(value) ? 0 : value);
@@ -73,6 +94,12 @@ export default function Encounter() {
     const handleArmorClassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = parseInt(e.target.value);
         setArmorClass(isNaN(value) ? 0 : value);
+    };
+
+    const handleToggleDeathSave = (index) => {
+        const newDeathSaves = [...deathSaves];
+        newDeathSaves[index] = (newDeathSaves[index] + 1) % 3;
+        setDeathSaves(newDeathSaves);
     };
 
     const handleSendLog = () => {
@@ -500,9 +527,17 @@ export default function Encounter() {
                         </Box>
 
                         {/* Death Saves */}
-                        <Box sx={sxProps.deathSaves}>
-                            <Typography>☠</Typography>
-                            <Box>□□□□□</Box>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                            <Typography>Death Saves</Typography>
+                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                {deathSaves.map((state, index) => (
+                                    <DeathSaveBox
+                                        key={index}
+                                        state={state}
+                                        onClick={() => handleToggleDeathSave(index)}
+                                    />
+                                ))}
+                            </Box>
                         </Box>
                     </Card>
 
@@ -670,7 +705,7 @@ export default function Encounter() {
                 </Box>
                 
                 {/* Add Button */}
-                <Card sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 1, borderRadius: 0.5 }}>
+                <Card sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 1, borderRadius: 0.5, width: '18vw' }}>
                     <IconButton size="small">
                         <AddIcon onClick={handleAddInitiative} />
                     </IconButton>
@@ -747,9 +782,17 @@ export default function Encounter() {
                         </Box>
 
                         {/* Death Saves */}
-                        <Box sx={sxProps.deathSaves}>
-                            <Typography>☠</Typography>
-                            <Box>□□□□□</Box>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                            <Typography>Death Saves</Typography>
+                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                {deathSaves.map((state, index) => (
+                                    <DeathSaveBox
+                                        key={index}
+                                        state={state}
+                                        onClick={() => handleToggleDeathSave(index)}
+                                    />
+                                ))}
+                            </Box>
                         </Box>
                     </Card>
 

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -645,8 +645,8 @@ export default function Encounter() {
                     {/* Status */}
                     <Card sx={{ ...sxProps.columnCard, flex: 1 }}>
                         <Typography variant="subtitle2">Status</Typography>
-                                
-                        {/* HP Row */}
+
+                        {/* HP */}
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                             <Typography sx={{ flexGrow: 1 }}>HP</Typography>
                             <TextField
@@ -654,7 +654,7 @@ export default function Encounter() {
                                 value={currentHP}
                                 onChange={handleCurrentHPChange}
                                 size="small"
-                                sx={{ width: 60, ml: 'auto' }}  // Text field aligned to the right
+                                sx={{ width: 60, ml: 'auto' }}
                             />
                             <Typography>/</Typography>
                             <TextField
@@ -665,8 +665,8 @@ export default function Encounter() {
                                 sx={{ width: 60 }}
                             />
                         </Box>
-                                
-                        {/* Temp HP Row */}
+
+                        {/* Temp HP */}
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                             <Typography sx={{ flexGrow: 1 }}>Temp HP</Typography>
                             <TextField
@@ -674,11 +674,11 @@ export default function Encounter() {
                                 value={tempHP}
                                 onChange={handleTempHPChange}
                                 size="small"
-                                sx={{ width: 100, ml: 'auto' }}  // Text field aligned to the right
+                                sx={{ width: 100, ml: 'auto' }}
                             />
                         </Box>
-                                
-                        {/* AC Row */}
+
+                        {/* AC */}
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <Typography sx={{ flexGrow: 1 }}>AC</Typography>
                             <TextField
@@ -686,7 +686,7 @@ export default function Encounter() {
                                 value={armorClass}
                                 onChange={handleArmorClassChange}
                                 size="small"
-                                sx={{ width: 100, ml: 'auto' }}  // Text field aligned to the right
+                                sx={{ width: 100, ml: 'auto' }}
                             />
                         </Box>
                     </Card>

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -755,14 +755,6 @@ export default function Encounter() {
                 <Card sx={sxProps.columnCard}>
                     <Box sx={sxProps.actionGroup}>
                         <Box sx={sxProps.actionItem}>
-                            <Typography>Type</Typography>
-                            <TextField
-                            placeholder="Type here..."
-                            size="small"
-                            fullWidth
-                        />
-                        </Box>
-                        <Box sx={sxProps.actionItem}>
                             <Typography>Action</Typography>
                             <Select value={selectedAction} onChange={(e) => setSelectedAction(e.target.value as Action)} size="small" fullWidth>
                                 {actionOptions.map((action) => (

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -284,8 +284,15 @@ export default function Encounter() {
         encounterColumn: {
             display: "flex",
             flexDirection: "column",
+            flex: 1,
             gap: 1,
-            width: 'fit-content'
+        },
+        initiativeQueueColumn: {
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            flex: 0,
+            width: "fit-content",
         },
         columnTitle: {
             marginBottom: 0.5
@@ -591,7 +598,7 @@ export default function Encounter() {
 
     return (
         <Box sx={sxProps.encounterScreen}>
-            <Box sx={sxProps.encounterColumn}>
+            <Box sx={sxProps.initiativeQueueColumn}>
                 <Typography variant="h6" sx={sxProps.columnTitle}>INITIATIVE</Typography>
                 <Box sx={{ maxHeight: '70vh', overflowY: 'auto', pr: 1 }}>
                     {players.map((character, index) => (

--- a/frontend/src/routes/encounter.tsx
+++ b/frontend/src/routes/encounter.tsx
@@ -75,6 +75,13 @@ export default function Encounter() {
         setArmorClass(isNaN(value) ? 0 : value);
     };
 
+    const handleSendLog = () => {
+        if (logInput.trim()) {
+            addCombatLogEntry(`• ${logInput}`);
+            setLogInput(""); // Clear the input field
+        }
+    };
+
     const [currentPlayer, setCurrentPlayer] = useState(null);
     const [error, setError] = useState<string | null>(null);
 
@@ -112,6 +119,8 @@ export default function Encounter() {
     const [selectedImmunities, setSelectedImmunities] = useState<string[]>([]);
     const [selectedResistances, setSelectedResistances] = useState<string[]>([]);
     const [selectedVulnerabilities, setSelectedVulnerabilities] = useState<string[]>([]);
+
+    const [logInput, setLogInput] = useState<string>("");
 
     const handleConditionsOpen = async () => {
         const conditions = await dialogs.open(CharacterConditions, selectedConditions);
@@ -795,10 +804,12 @@ export default function Encounter() {
                             placeholder="Type here..."
                             size="small"
                             fullWidth
+                            value={logInput}
+                            onChange={(e) => setLogInput(e.target.value)}
                             InputProps={{
                                 endAdornment: (
                                     <InputAdornment position="end">
-                                        <IconButton edge="end">
+                                        <IconButton edge="end" onClick={handleSendLog}>
                                             <Send />
                                         </IconButton>
                                     </InputAdornment>

--- a/frontend/src/routes/landing.tsx
+++ b/frontend/src/routes/landing.tsx
@@ -6,7 +6,7 @@ export default function Landing() {
     
     return (
         <Container sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2, pt: 8 }}>
-            <Typography variant={"h3"}>Placeholder landing page</Typography>
+            <Typography variant={"h3"}>Welcome to Dungeon Master's Codex</Typography>
             <AuthButton loginStatus={LoginStatus.LoggedOut} />
         </Container>
     )


### PR DESCRIPTION
- Combat log now allows custom input. Currently does not save it, so it will be cleared when the campaign is closed/opened again.
- Randomise rolls button added to Attack modal.
- Attack modal displays total sum of damage.
- Add Player To Initiative Queue button is now sticky.
- Removed "Type" text field from the Current Turn section.
- Updated the look of the Encounter screen.
- Added Death Saves in the form of custom checkboxes to the Encounter Screen. Missing backend functionality.